### PR TITLE
Change the modules to adhere to the UMD API

### DIFF
--- a/lalolab/src/modules/lalolib-moduleFooter.js
+++ b/lalolab/src/modules/lalolib-moduleFooter.js
@@ -336,4 +336,4 @@ return {
 	bfgs: bfgs
 	
 }
-})();
+}));

--- a/lalolab/src/modules/lalolib-moduleHeader.js
+++ b/lalolab/src/modules/lalolib-moduleHeader.js
@@ -1,4 +1,14 @@
-var lalolib = (function () {
-
-
-
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {

--- a/lalolab/src/modules/lalolib-noglpk-moduleFooter.js
+++ b/lalolab/src/modules/lalolib-noglpk-moduleFooter.js
@@ -318,4 +318,4 @@ return {
 	bfgs: bfgs
 	
 }
-})();
+}));

--- a/lalolab/src/modules/mljs-moduleFooter.js
+++ b/lalolab/src/modules/mljs-moduleFooter.js
@@ -398,4 +398,4 @@ return {
 	bfgs: bfgs
 	
 }
-})();
+}));

--- a/lalolab/src/modules/mljs-moduleHeader.js
+++ b/lalolab/src/modules/mljs-moduleHeader.js
@@ -1,4 +1,14 @@
-var mljs = (function () {
-
-
-
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {

--- a/lalolab/src/modules/mljs-noglpk-moduleFooter.js
+++ b/lalolab/src/modules/mljs-noglpk-moduleFooter.js
@@ -380,4 +380,4 @@ return {
 	bfgs: bfgs
 	
 }
-})();
+}));


### PR DESCRIPTION
This is a simple change to the header and footer of the module compilations. [The universal module defintion](https://www.davidbcalhoun.com/2014/what-is-amd-commonjs-and-umd/) makes MLWeb easily usable from as many environments as possible. Currently the modules assign a global variable which is fine in many cases but may not be compatible with various `require` implementation (including [d3](https://github.com/d3/d3)'s require implementation used by [Observable notebooks](https://beta.observablehq.com/))