### PR TITLE
Fix small error in solveGaussianElimination

### DIFF
--- a/lalolab/src/linalg.js
+++ b/lalolab/src/linalg.js
@@ -5112,7 +5112,7 @@ function solveGaussianElimination(Aorig, borig) {
 		}
 		if ( isZero( Aimaxk ) ) {
 			console.log("** Warning in solve(A,b), A is square but singular, switching from Gaussian elimination to QR method.");
-			return solveWithQRcolumnpivoting(A,b);
+			return solveWithQRcolumnpivoting(Aorig, borig);
 		} 
 		
 		if ( imax != k ) {


### PR DESCRIPTION
When switching to solveWithQRcolumnpivoting needs to use the original matrix.